### PR TITLE
Corrección de errores

### DIFF
--- a/wiki/Equilibrio.md
+++ b/wiki/Equilibrio.md
@@ -8,13 +8,15 @@ Lo cual se da cuando la partícula está en reposo o bien viajando a una velocid
 
 Usando las leyes de Newton, es posible demostrar esta propiedad para un conjunto de partículas, por lo que es válida cuando se pretende analizar un ***sistema aislado***. Sin embargo, estos tienen que cumplir además con:
 
- - **Suma de momentos debe ser nula:** al poseer una distribución de masa, los objetos pueden rotar. Esta propiedad tiene que ser válida para cualquier eje $\overline{OO}$ dentro o fuera del sistema.
+ - **Suma de momentos debe ser nula:** al poseer una distribución de masa, los objetos pueden rotar. Esta propiedad tiene que ser válida para cualquier eje $$\overline{OO}$$ dentro o fuera del sistema.
  
  $$\vec{M}_{OO} = \sum_{i=1}^n (\vec{r}_i \times \vec{F}_i) = 0$$
 
  - **Suma de fuerzas internas y externas debe ser nula:** Las fuerzas que actúan tanto dentro como fuera del sistema deben cancelarse entre sí.
  
  $$\sum_{i=1}^n \vec{F}_{i,\ int} + \sum_{j=1}^m \vec{F}_{j,\ ext} = 0$$
+ 
+Si además, estas propiedades cumplen para cualquier subsistema aislado tomado dentro del original (e.g. un conjunto de partículas dentro de él), entonces estamos ante un ***sistema deformable en equilibrio***.
  
 Tomando como ejemplo un trampolín de piscina, podemos decir que este está en equilibrio cuando nadie lo está usando, puesto que toda su estructura se mantiene en reposo. Sin embargo, si alguien decide usarlo, este experimentará una fuerza en un extremo, por lo que una parte de el comenzará a oscilar, rompiendo la condición de la suma de los momentos.
 


### PR DESCRIPTION
Corregí el $\overline{OO}$ a $$\overline{OO}$$ y agregué un párrafo que me pareció importante: "Si además, estas propiedades cumplen para cualquier subsistema aislado tomado dentro del original (e.g. un conjunto de partículas dentro de él), entonces estamos ante un ***sistema deformable en equilibrio***."